### PR TITLE
The boundingBox attribute in DetectedText should be DOMRectReadOnly

### DIFF
--- a/text.bs
+++ b/text.bs
@@ -80,7 +80,7 @@ Example implementations of Text code detection are e.g. <a href="https://develop
 [
     Constructor,
 ] interface DetectedText {
-  [SameObject] readonly attribute DOMRect boundingBox;
+  [SameObject] readonly attribute DOMRectReadOnly boundingBox;
   [SameObject] readonly attribute DOMString rawValue;
   [SameObject] readonly attribute FrozenArray&lt;Point2D> cornerPoints;
 };


### PR DESCRIPTION
There is no reason to allow developers to overwrite `boudingBox`'s properties.
So the attribute should be DOMRectReadOnly.