### PR TITLE
Remove static from getSupportedFormats specification.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -188,7 +188,7 @@ Example implementations of Barcode/QR code detection are e.g. <a href="https://d
 [Exposed=(Window,Worker),
  Constructor(optional BarcodeDetectorOptions barcodeDetectorOptions)]
 interface BarcodeDetector {
-  static Promise<sequence<BarcodeFormat>> getSupportedFormats();
+  Promise<sequence<BarcodeFormat>> getSupportedFormats();
 
   Promise<sequence<DetectedBarcode>> detect(ImageBitmapSource image);
 };


### PR DESCRIPTION
getSupportedFormats requires access to the Mojo service, which is a member variable and cannot be accessed from static methods.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jchinlee/shape-detection-api/pull/63.html" title="Last updated on Feb 19, 2019, 5:19 PM UTC (0cd908e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/shape-detection-api/63/a7f576d...jchinlee:0cd908e.html" title="Last updated on Feb 19, 2019, 5:19 PM UTC (0cd908e)">Diff</a>