### PR TITLE
Add [Exposed=Window,Worker] to Detected{Barcode,Face,Text}

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -123,7 +123,7 @@ dictionary FaceDetectorOptions {
 ### {{DetectedFace}} ### {#detectedface-section}
 
 <xmp class="idl">
-[Serializable]
+[Exposed=(Window,Worker), Serializable]
 interface DetectedFace {
   [SameObject] readonly attribute DOMRectReadOnly boundingBox;
   [SameObject] readonly attribute FrozenArray<Landmark>? landmarks;
@@ -238,7 +238,7 @@ dictionary BarcodeDetectorOptions {
 ### {{DetectedBarcode}} ### {#detectedbarcode-section}
 
 <xmp class="idl">
-[Serializable]
+[Exposed=(Window,Worker), Serializable]
 interface DetectedBarcode {
   [SameObject] readonly attribute DOMRectReadOnly boundingBox;
   [SameObject] readonly attribute DOMString rawValue;

--- a/text.bs
+++ b/text.bs
@@ -79,10 +79,8 @@ Example implementations of Text code detection are e.g. <a href="https://develop
 ### {{DetectedText}} ### {#detectedtext-section}
 
 <xmp class="idl">
-[
-    Constructor,
-    Serializable
-] interface DetectedText {
+[Exposed=(Window,Worker), Serializable]
+interface DetectedText {
   [SameObject] readonly attribute DOMRectReadOnly boundingBox;
   [SameObject] readonly attribute DOMString rawValue;
   [SameObject] readonly attribute FrozenArray<Point2D> cornerPoints;


### PR DESCRIPTION
and remove [Constructor] from DetectedText interface


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Honry/shape-detection-api/pull/64.html" title="Last updated on Mar 12, 2019, 8:36 AM UTC (5600abd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/shape-detection-api/64/a7f576d...Honry:5600abd.html" title="Last updated on Mar 12, 2019, 8:36 AM UTC (5600abd)">Diff</a>