### PR TITLE
Specify behavior when BarcodeDetectorOptions.formats is not present

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -201,8 +201,8 @@ interface BarcodeDetector {
 <dl class="domintro">
   <dt><dfn constructor for="BarcodeDetector"><code>BarcodeDetector(optional BarcodeDetectorOptions |barcodeDetectorOptions|)</code></dfn></dt>
   <dd>Constructs a new {{BarcodeDetector}} with |barcodeDetectorOptions|.
-    * If |barcodeDetectorOptions|.|formats| is present and empty, then throw a new {{TypeError}}.
-    * If |barcodeDetectorOptions|.|formats| is present and contains {{unknown}}, then throw a new {{TypeError}}.
+    * If |barcodeDetectorOptions|.{{BarcodeDetectorOptions/formats}} is present and empty, then throw a new {{TypeError}}.
+    * If |barcodeDetectorOptions|.{{BarcodeDetectorOptions/formats}} is present and contains {{unknown}}, then throw a new {{TypeError}}.
   <div class="note">
     Detectors may potentially allocate and hold significant resources. Where possible, reuse the same {{BarcodeDetector}} for several detections.
   </div>

--- a/index.bs
+++ b/index.bs
@@ -200,12 +200,12 @@ interface BarcodeDetector {
 
 <dl class="domintro">
   <dt><dfn constructor for="BarcodeDetector"><code>BarcodeDetector(optional BarcodeDetectorOptions |barcodeDetectorOptions|)</code></dfn></dt>
-  <dd>Constructs a new {{BarcodeDetector}} with the optional |barcodeDetectorOptions|, if present.
-    * If |barcodeDetectorOptions| is passed, and its |formats| are empty, then throw a new {{TypeError}}.
-    * If |barcodeDetectorOptions| is passed, and its |formats| contain {{unknown}}, then throw a new {{TypeError}}.
-    <div class="note">
+  <dd>Constructs a new {{BarcodeDetector}} with |barcodeDetectorOptions|.
+    * If |barcodeDetectorOptions|.|formats| is present and empty, then throw a new {{TypeError}}.
+    * If |barcodeDetectorOptions|.|formats| is present and contains {{unknown}}, then throw a new {{TypeError}}.
+  <div class="note">
     Detectors may potentially allocate and hold significant resources. Where possible, reuse the same {{BarcodeDetector}} for several detections.
-    </div>
+  </div>
   </dd>
 
   <dt><dfn method for="BarcodeDetector">`getSupportedFormats()`</dfn></dt>
@@ -238,7 +238,11 @@ dictionary BarcodeDetectorOptions {
 
 <dl class="domintro">
   <dt><dfn dict-member for="BarcodeDetectorOptions">`formats`</dfn></dt>
-  <dd>A series of {{BarcodeFormat}}s to search for in the subsequent {{BarcodeDetector/detect()}} calls.</dd>
+  <dd>A series of {{BarcodeFormat}}s to search for in the subsequent {{BarcodeDetector/detect()}} calls. If not present then the UA SHOULD search for all supported formats.
+  <div class="note">
+    Limiting the search to a particular subset of supported formats is likely to provide better performance.
+  </div>
+  </dd>
 </dl>
 
 ### {{DetectedBarcode}} ### {#detectedbarcode-section}


### PR DESCRIPTION
This change resolves confusion around the `barcodeDetectorOptions` argument to the BarcodeDetector constructor. As it is an optional parameter in trailing position it will always be default initialized and so always present. However, the `formats` member does not have a default value and so may not be present. This change clarifies the behavior in these cases.

Fixes #74.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/reillyeon/shape-detection-api/pull/75.html" title="Last updated on Jul 26, 2019, 10:07 PM UTC (3caab83)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/shape-detection-api/75/e7a83a5...reillyeon:3caab83.html" title="Last updated on Jul 26, 2019, 10:07 PM UTC (3caab83)">Diff</a>