### PR TITLE
Resolve with an empty array when barcode detection unsupported

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -209,15 +209,16 @@ interface BarcodeDetector {
   </dd>
 
   <dt><dfn method for="BarcodeDetector">`getSupportedFormats()`</dfn></dt>
-  <dd> This method, when invoked, MUST return a new {{Promise}} `promise` and run the following steps <a>in parallel</a>:
+  <dd>This method, when invoked, MUST return a new {{Promise}} |promise| and run the following steps <a>in parallel</a>:
     <ol>
-     <li>If the UA does not support barcode detection, reject `promise` with a {{NotSupportedError}} and abort these steps.</li>
-     <li>Enumerate the {{BarcodeFormat}}s that the UA understands as potentially detectable in images. Let this be `supportedFormats`.
-     <div class="note">
-      The UA cannot give a definitive answer as to whether a given barcode format will <i>always</i> be recognized on an image due to e.g. positioning of the symbols or encoding errors. If a given barcode symbology is not in the `supportedFormats` array, however, it should not be detectable whatsoever.
-     </div>
-     </li>
-     <li>Resolve `promise` with `supportedFormats`.</li>
+      <li>Let |supportedFormats| be a new {{Array}}.</li>
+      <li>If the UA does not support barcode detection, resolve |promise| with |supportedFormats| and abort these steps.</li>
+      <li>Enumerate the {{BarcodeFormat}}s that the UA understands as potentially detectable in images. Add these to |supportedFormats|.
+      <div class="note">
+        The UA cannot give a definitive answer as to whether a given barcode format will <i>always</i> be recognized on an image due to e.g. positioning of the symbols or encoding errors. If a given barcode symbology is not in |supportedFormats| array, however, it should not be detectable whatsoever.
+      </div>
+      </li>
+      <li>Resolve |promise| with |supportedFormats|.</li>
    </ol>
   <div class="note">
     The list of supported {{BarcodeFormat}}s is platform dependent, some examples are the ones supported by <a href="https://developers.google.com/android/reference/com/google/android/gms/vision/barcode/BarcodeDetector.Builder.html#setBarcodeFormats(int)">Google Play Services</a> and <a href="https://developer.apple.com/documentation/coreimage/ciqrcodefeature?preferredLanguage=occ#overview">Apple's QICRCodeFeature</a>.


### PR DESCRIPTION
This change modifies the behavior of `BarcodeDetector.getSupportedFormats()` such that it resolves with an empty array when barcode detection is not supported by the platform, rather than rejecting.

This matches the behavior in Chromium which is based on developer [feedback](https://github.com/PaulKinlan/qrcode/pull/59#issuecomment-511176568) indicating that this makes feature detection easier as otherwise developers must handle rejection and check that the desired format is present in the result.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/reillyeon/shape-detection-api/pull/76.html" title="Last updated on Jul 26, 2019, 9:47 PM UTC (0033933)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/shape-detection-api/76/e7a83a5...reillyeon:0033933.html" title="Last updated on Jul 26, 2019, 9:47 PM UTC (0033933)">Diff</a>