### PR TITLE
Update links to HTML concepts

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -65,15 +65,15 @@ This section is inspired by [[2dcontext#image-sources-for-2d-rendering-contexts]
 
 When the UA is required to use a given type of {{ImageBitmapSource}} as input argument for the `detect()` method of whichever detector, it MUST run these steps:
 
-* If any {{ImageBitmapSource}} have an effective script origin ([[HTML#concept-origin]]) which is not the same as the Document's effective script origin, then reject the Promise with a new {{DOMException}} whose name is {{SecurityError}}.
+* If any {{ImageBitmapSource}} have an effective script origin ([=origin=]) which is not the same as the Document's effective script origin, then reject the Promise with a new {{DOMException}} whose name is {{SecurityError}}.
 
-* If the {{ImageBitmapSource}} is an {{HTMLImageElement}} object that is in the `Broken` ([[HTML#img-error]]) state, then reject the Promise with a new {{DOMException}} whose name is {{InvalidStateError}}, and abort any further steps.
+* If the {{ImageBitmapSource}} is an {{HTMLImageElement}} object that is in the `Broken` (<a href="https://html.spec.whatwg.org/multipage/#img-error">HTML Standard §img-error</a>) state, then reject the Promise with a new {{DOMException}} whose name is {{InvalidStateError}}, and abort any further steps.
 
 * If the {{ImageBitmapSource}} is an {{HTMLImageElement}} object that is not fully decodable then reject the Promise with a new {{DOMException}} whose name is {{InvalidStateError}}, and abort any further steps
 
 * If the {{ImageBitmapSource}} is an {{HTMLVideoElement}} object whose {{HTMLMediaElement/readyState}} attribute is either {{HAVE_NOTHING}} or {{HAVE_METADATA}} then reject the Promise with a new {{DOMException}} whose name is {{InvalidStateError}}, and abort any further steps.
 
-* If the {{ImageBitmapSource}} argument is an {{HTMLCanvasElement}} whose bitmap's `origin-clean` ([[HTML#concept-canvas-origin-clean]]) flag is false, then reject the Promise with a new {{DOMException}} whose name is {{SecurityError}}, and abort any further steps.
+* If the {{ImageBitmapSource}} argument is an {{HTMLCanvasElement}} whose bitmap's `origin-clean` (<a href="https://html.spec.whatwg.org/multipage/#concept-canvas-origin-clean">HTML Standard §concept-canvas-origin-clean</a>) flag is false, then reject the Promise with a new {{DOMException}} whose name is {{SecurityError}}, and abort any further steps.
 
 Note that if the {{ImageBitmapSource}} is an object with either a horizontal dimension or a vertical dimension equal to zero, then the Promise will be simply resolved with an empty sequence of detected objects.
 
@@ -457,6 +457,8 @@ spec: html
         text: allowed to show a popup
         text: in parallel
         text: incumbent settings object
+        for: /
+            text: origin
 </pre>
 
 <pre class="biblio">


### PR DESCRIPTION
This partially fixes #84 by updating the link to the HTML "origin" concept to be a proper reference to the definition in the HTML specification. For the image "Broken" state and "origin clean" concepts
however there is no appropriate definition currently exported by the HTML specification and so these have been replaced with explicit links rather than autolinks. This is non-ideal but a necessary workaround to allow this specification to compile while we work on getting the necessary references exported by HTML.

CC @tabatkins


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/reillyeon/shape-detection-api/pull/85.html" title="Last updated on Feb 5, 2020, 10:39 PM UTC (a440c13)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/shape-detection-api/85/b18f615...reillyeon:a440c13.html" title="Last updated on Feb 5, 2020, 10:39 PM UTC (a440c13)">Diff</a>