### PR TITLE
Change detection result types to dictionaries

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -124,19 +124,16 @@ dictionary FaceDetectorOptions {
 ### {{DetectedFace}} ### {#detectedface-section}
 
 <xmp class="idl">
-[Exposed=(Window,Worker),
- SecureContext,
- Serializable]
-interface DetectedFace {
-  [SameObject] readonly attribute DOMRectReadOnly boundingBox;
-  [SameObject] readonly attribute FrozenArray<Landmark>? landmarks;
+dictionary DetectedFace {
+  required DOMRectReadOnly boundingBox;
+  required FrozenArray<Landmark>? landmarks;
 };
 </xmp>
 
 <dl class="domintro">
-  <dt><dfn attribute for="DetectedFace">`boundingBox`</dfn></dt>
+  <dt><dfn dict-member for="DetectedFace">`boundingBox`</dfn></dt>
   <dd>A rectangle indicating the position and extent of a detected feature aligned to the image axes.</dd>
-  <dt><dfn attribute for="DetectedFace">`landmarks`</dfn></dt>
+  <dt><dfn dict-member for="DetectedFace">`landmarks`</dfn></dt>
   <dd>A series of features of interest related to the detected feature.</dd>
 </dl>
 
@@ -249,28 +246,25 @@ dictionary BarcodeDetectorOptions {
 ### {{DetectedBarcode}} ### {#detectedbarcode-section}
 
 <xmp class="idl">
-[Exposed=(Window,Worker),
- SecureContext,
- Serializable]
-interface DetectedBarcode {
-  [SameObject] readonly attribute DOMRectReadOnly boundingBox;
-  [SameObject] readonly attribute DOMString rawValue;
-  [SameObject] readonly attribute BarcodeFormat format;
-  [SameObject] readonly attribute FrozenArray<Point2D> cornerPoints;
+dictionary DetectedBarcode {
+  required DOMRectReadOnly boundingBox;
+  required DOMString rawValue;
+  required BarcodeFormat format;
+  required FrozenArray<Point2D> cornerPoints;
 };
 </xmp>
 
 <dl class="domintro">
-  <dt><dfn attribute for="DetectedBarcode">`boundingBox`</dfn></dt>
+  <dt><dfn dict-member for="DetectedBarcode">`boundingBox`</dfn></dt>
   <dd>A rectangle indicating the position and extent of a detected feature aligned to the image</dd>
 
-  <dt><dfn attribute for="DetectedBarcode">`rawValue`</dfn></dt>
+  <dt><dfn dict-member for="DetectedBarcode">`rawValue`</dfn></dt>
   <dd>String decoded from the barcode. This value might be multiline.</dd>
 
-  <dt><dfn attribute for="DetectedBarcode">`format`</dfn></dt>
+  <dt><dfn dict-member for="DetectedBarcode">`format`</dfn></dt>
   <dd>Detect {{BarcodeFormat}}.</dd>
 
-  <dt><dfn attribute for="DetectedBarcode">`cornerPoints`</dfn></dt>
+  <dt><dfn dict-member for="DetectedBarcode">`cornerPoints`</dfn></dt>
   <dd>A <a>sequence</a> of corner points of the detected barcode, in clockwise direction and  starting with top-left. This is not necessarily a square due to possible perspective distortions.</dd>
 </dl>
 

--- a/index.bs
+++ b/index.bs
@@ -65,15 +65,15 @@ This section is inspired by [[2dcontext#image-sources-for-2d-rendering-contexts]
 
 When the UA is required to use a given type of {{ImageBitmapSource}} as input argument for the `detect()` method of whichever detector, it MUST run these steps:
 
-* If any {{ImageBitmapSource}} have an effective script origin ([[HTML#concept-origin]]) which is not the same as the Document's effective script origin, then reject the Promise with a new {{DOMException}} whose name is {{SecurityError}}.
+* If any {{ImageBitmapSource}} have an effective script origin ([=origin=]) which is not the same as the Document's effective script origin, then reject the Promise with a new {{DOMException}} whose name is {{SecurityError}}.
 
-* If the {{ImageBitmapSource}} is an {{HTMLImageElement}} object that is in the `Broken` ([[HTML#img-error]]) state, then reject the Promise with a new {{DOMException}} whose name is {{InvalidStateError}}, and abort any further steps.
+* If the {{ImageBitmapSource}} is an {{HTMLImageElement}} object that is in the `Broken` (<a href="https://html.spec.whatwg.org/multipage/#img-error">HTML Standard §img-error</a>) state, then reject the Promise with a new {{DOMException}} whose name is {{InvalidStateError}}, and abort any further steps.
 
 * If the {{ImageBitmapSource}} is an {{HTMLImageElement}} object that is not fully decodable then reject the Promise with a new {{DOMException}} whose name is {{InvalidStateError}}, and abort any further steps
 
 * If the {{ImageBitmapSource}} is an {{HTMLVideoElement}} object whose {{HTMLMediaElement/readyState}} attribute is either {{HAVE_NOTHING}} or {{HAVE_METADATA}} then reject the Promise with a new {{DOMException}} whose name is {{InvalidStateError}}, and abort any further steps.
 
-* If the {{ImageBitmapSource}} argument is an {{HTMLCanvasElement}} whose bitmap's `origin-clean` ([[HTML#concept-canvas-origin-clean]]) flag is false, then reject the Promise with a new {{DOMException}} whose name is {{SecurityError}}, and abort any further steps.
+* If the {{ImageBitmapSource}} argument is an {{HTMLCanvasElement}} whose bitmap's `origin-clean` (<a href="https://html.spec.whatwg.org/multipage/#concept-canvas-origin-clean">HTML Standard §concept-canvas-origin-clean</a>) flag is false, then reject the Promise with a new {{DOMException}} whose name is {{SecurityError}}, and abort any further steps.
 
 Note that if the {{ImageBitmapSource}} is an object with either a horizontal dimension or a vertical dimension equal to zero, then the Promise will be simply resolved with an empty sequence of detected objects.
 
@@ -457,6 +457,8 @@ spec: html
         text: allowed to show a popup
         text: in parallel
         text: incumbent settings object
+        for: /
+            text: origin
 </pre>
 
 <pre class="biblio">

--- a/text.bs
+++ b/text.bs
@@ -80,25 +80,21 @@ Example implementations of Text code detection are e.g. <a href="https://develop
 ### {{DetectedText}} ### {#detectedtext-section}
 
 <xmp class="idl">
-[
-    Exposed=(Window,Worker),
-    SecureContext,
-    Serializable
-] interface DetectedText {
-  [SameObject] readonly attribute DOMRectReadOnly boundingBox;
-  [SameObject] readonly attribute DOMString rawValue;
-  [SameObject] readonly attribute FrozenArray<Point2D> cornerPoints;
+dictionary DetectedText {
+  required DOMRectReadOnly boundingBox;
+  required DOMString rawValue;
+  required FrozenArray<Point2D> cornerPoints;
 };
 </xmp>
 
 <dl class="domintro">
-  <dt><dfn attribute for="DetectedText">`boundingBox`</dfn></dt>
+  <dt><dfn dict-member for="DetectedText">`boundingBox`</dfn></dt>
   <dd>A rectangle indicating the position and extent of a detected feature aligned to the image</dd>
 
-  <dt><dfn attribute for="DetectedText">`rawValue`</dfn></dt>
+  <dt><dfn dict-member for="DetectedText">`rawValue`</dfn></dt>
   <dd>Raw string detected from the image, where characters are drawn from [[iso8859-1]].</dd>
 
-  <dt><dfn attribute for="DetectedText">`cornerPoints`</dfn></dt>
+  <dt><dfn dict-member for="DetectedText">`cornerPoints`</dfn></dt>
   <dd>A <a>sequence</a> of corner points of the detected feature, in clockwise direction and  starting with top-left. This is not necessarily a square due to possible perspective distortions.</dd>
 </dl>
 


### PR DESCRIPTION
As shape detection results are data without behavior they do not need to be interfaces. The advantage of dictionary types is that they are automatically serializable, thus reducing implementation burden. They also don't pollute the global namespace with useless types.

This ends up resolving #65 by making all the other types match Landmark.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/reillyeon/shape-detection-api/pull/86.html" title="Last updated on Feb 5, 2020, 10:56 PM UTC (1b38e16)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/shape-detection-api/86/b18f615...reillyeon:1b38e16.html" title="Last updated on Feb 5, 2020, 10:56 PM UTC (1b38e16)">Diff</a>