### PR TITLE
Update Python on Travis CI to 3.7 to fix Bikeshed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 sudo: false
 python:
-  - "2.7"
+  - "3.7"
 
 install:
   # Setup bikeshed. See https://tabatkins.github.io/bikeshed/#install-linux


### PR DESCRIPTION
Bikeshed now requires Python >= 3.7.