### PR TITLE
Fix broken links by removing unnecessary anchors

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -429,22 +429,6 @@ barcodeDetector.detect(theImage)
 ```
 </div>
 
-<pre class="anchors">
-spec: ECMAScript; urlPrefix: https://tc39.github.io/ecma262/#
-    type: interface
-        text: Array; url: sec-array-objects
-        text: Promise; url:sec-promise-objects
-        text: TypeError; url: sec-native-error-types-used-in-this-standard-typeerror
-</pre>
-
-<pre class="anchors">
-type: interface; text: Point2D; url: https://w3c.github.io/mediacapture-image/#Point2D;
-</pre>
-
-<pre class="anchors">
-type: interface; text: DOMString; url: https://heycam.github.io/webidl/#idl-DOMString; spec: webidl
-</pre>
-
 <pre class="link-defaults">
 spec: html
     type: dfn

--- a/text.bs
+++ b/text.bs
@@ -148,23 +148,6 @@ textDetector.detect(theImage)
 ```
 </div>
 
-
-<pre class="anchors">
-spec: ECMAScript; urlPrefix: https://tc39.github.io/ecma262/#
-    type: interface
-        text: Array; url: sec-array-objects
-        text: Promise; url:sec-promise-objects
-        text: TypeError; url: sec-native-error-types-used-in-this-standard-typeerror
-</pre>
-
-<pre class="anchors">
-type: interface; text: Point2D; url: https://w3c.github.io/mediacapture-image/#Point2D;
-</pre>
-
-<pre class="anchors">
-type: interface; text: DOMString; url: https://heycam.github.io/webidl/#idl-DOMString; spec: webidl
-</pre>
-
 <pre class="link-defaults">
 spec: html
     type: dfn


### PR DESCRIPTION
Bikeshed can now correctly link to Array, DOMString, Point2D, Promise and TypeError without explicit anchor definitions. In the case of Point2D the anchor had become stale.

Fixed #94, #95.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/shape-detection-api/pull/97.html" title="Last updated on Jan 30, 2023, 5:49 PM UTC (ef22a71)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/shape-detection-api/97/2c0e96d...ef22a71.html" title="Last updated on Jan 30, 2023, 5:49 PM UTC (ef22a71)">Diff</a>