### PR TITLE
Replace FrozenArray<T> with sequence<T>

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -126,7 +126,7 @@ dictionary FaceDetectorOptions {
 <xmp class="idl">
 dictionary DetectedFace {
   required DOMRectReadOnly boundingBox;
-  required FrozenArray<Landmark>? landmarks;
+  required sequence<Landmark>? landmarks;
 };
 </xmp>
 
@@ -139,7 +139,7 @@ dictionary DetectedFace {
 
 <xmp class="idl">
 dictionary Landmark {
-  required FrozenArray<Point2D> locations;
+  required sequence<Point2D> locations;
   LandmarkType type;
 };
 </xmp>
@@ -250,7 +250,7 @@ dictionary DetectedBarcode {
   required DOMRectReadOnly boundingBox;
   required DOMString rawValue;
   required BarcodeFormat format;
-  required FrozenArray<Point2D> cornerPoints;
+  required sequence<Point2D> cornerPoints;
 };
 </xmp>
 

--- a/text.bs
+++ b/text.bs
@@ -83,7 +83,7 @@ Example implementations of Text code detection are e.g. <a href="https://develop
 dictionary DetectedText {
   required DOMRectReadOnly boundingBox;
   required DOMString rawValue;
-  required FrozenArray<Point2D> cornerPoints;
+  required sequence<Point2D> cornerPoints;
 };
 </xmp>
 


### PR DESCRIPTION
As suggested by #100, the WebIDL specification is trying to remove `FrozenArray`.

Fixed #100.